### PR TITLE
Make multiharp channel ids consistent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,9 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 
+[[shell]]
+simplify = true
+
 [*.py]
 indent_size = 4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
@@ -69,9 +69,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -84,36 +84,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys",
 ]
 
@@ -125,9 +125,9 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arrow"
-version = "55.0.0"
+version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3095aaf545942ff5abd46654534f15b03a90fba78299d661e045e5d587222f0d"
+checksum = "f3f15b4c6b148206ff3a2b35002e08929c2462467b62b9c02036d9c34f9ef994"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "55.0.0"
+version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00752064ff47cee746e816ddb8450520c3a52cbad1e256f6fa861a35f86c45e7"
+checksum = "30feb679425110209ae35c3fbf82404a39a4c0436bb3ec36164d8bffed2a4ce4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "55.0.0"
+version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cebfe926794fbc1f49ddd0cdaf898956ca9f6e79541efce62dabccfd81380472"
+checksum = "70732f04d285d49054a48b72c54f791bb3424abae92d27aafdf776c98af161c8"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "55.0.0"
+version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0303c7ec4cf1a2c60310fc4d6bbc3350cd051a17bf9e9c0a8e47b4db79277824"
+checksum = "169b1d5d6cb390dd92ce582b06b23815c7953e9dfaaea75556e89d890d19993d"
 dependencies = [
  "bytes",
  "half",
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "55.0.0"
+version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f769c5a218ea823d3760a743feba1ef7857cba114c01399a891c2fff34285"
+checksum = "e4f12eccc3e1c05a766cafb31f6a60a46c2f8efec9b74c6e0648766d30686af8"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "55.0.0"
+version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510db7dfbb4d5761826516cc611d97b3a68835d0ece95b034a052601109c0b1b"
+checksum = "012c9fef3f4a11573b2c74aec53712ff9fdae4a95f4ce452d1bbf088ee00f06b"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -217,15 +217,14 @@ dependencies = [
  "chrono",
  "csv",
  "csv-core",
- "lazy_static",
  "regex",
 ]
 
 [[package]]
 name = "arrow-data"
-version = "55.0.0"
+version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8affacf3351a24039ea24adab06f316ded523b6f8c3dbe28fbac5f18743451b"
+checksum = "8de1ce212d803199684b658fc4ba55fb2d7e87b213de5af415308d2fee3619c2"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -235,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "55.0.0"
+version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69880a9e6934d9cba2b8630dd08a3463a91db8693b16b499d54026b6137af284"
+checksum = "d9ea5967e8b2af39aff5d9de2197df16e305f47f404781d3230b2dc672da5d92"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -248,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "55.0.0"
+version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8dafd17a05449e31e0114d740530e0ada7379d7cb9c338fd65b09a8130960b0"
+checksum = "5709d974c4ea5be96d900c01576c7c0b99705f4a3eec343648cb1ca863988a9c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -270,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "55.0.0"
+version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "895644523af4e17502d42c3cb6b27cb820f0cb77954c22d75c23a85247c849e1"
+checksum = "6506e3a059e3be23023f587f79c82ef0bcf6d293587e3272d20f2d30b969b5a7"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -283,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "55.0.0"
+version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be8a2a4e5e7d9c822b2b8095ecd77010576d824f654d347817640acfc97d229"
+checksum = "52bf7393166beaf79b4bed9bfdf19e97472af32ce5b6b48169d321518a08cae2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -296,15 +295,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "55.0.0"
+version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7450c76ab7c5a6805be3440dc2e2096010da58f7cab301fdc996a4ee3ee74e49"
+checksum = "af7686986a3bf2254c9fb130c623cdcb2f8e1f15763e7c71c310f0834da3d292"
 
 [[package]]
 name = "arrow-select"
-version = "55.0.0"
+version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa5f5a93c75f46ef48e4001535e7b6c922eeb0aa20b73cf58d09e13d057490d8"
+checksum = "dd2b45757d6a2373faa3352d02ff5b54b098f5e21dccebc45a21806bc34501e5"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -316,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "55.0.0"
+version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7005d858d84b56428ba2a98a107fe88c0132c61793cf6b8232a1f9bfc0452b"
+checksum = "0377d532850babb4d927a06294314b316e23311503ed580ec6ce6a0158f49d40"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -342,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -374,15 +373,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "brotli"
-version = "7.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -391,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -401,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -425,9 +424,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "jobserver",
  "libc",
@@ -445,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
@@ -503,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -513,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -525,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -537,15 +536,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "console"
@@ -588,9 +587,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -658,9 +657,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "csv"
@@ -713,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "libz-rs-sys",
@@ -730,7 +729,7 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -764,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -776,9 +775,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "humantime"
@@ -812,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -907,12 +906,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "lexical-core"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,18 +971,18 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libloading"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -1000,9 +993,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libz-rs-sys"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6489ca9bd760fe9642d7644e827b0c9add07df89857b0416ee15c1cc1a3b8c5a"
+checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
 dependencies = [
  "zlib-rs",
 ]
@@ -1015,18 +1008,18 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
 dependencies = [
- "twox-hash 1.6.3",
+ "twox-hash",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memoffset"
@@ -1045,9 +1038,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -1149,6 +1142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,9 +1164,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "55.0.0"
+version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd31a8290ac5b19f09ad77ee7a1e6a541f1be7674ad410547d5f1eef6eef4a9c"
+checksum = "b17da4150748086bd43352bc77372efa9b6e3dbd06a04831d2a98c041c225cfa"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -1192,7 +1191,7 @@ dependencies = [
  "simdutf8",
  "snap",
  "thrift",
- "twox-hash 2.1.0",
+ "twox-hash",
  "zstd",
 ]
 
@@ -1238,15 +1237,15 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1263,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f239d656363bcee73afef85277f1b281e8ac6212a1d42aa90e55b90ed43c47a4"
+checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
 dependencies = [
  "anyhow",
  "indoc",
@@ -1281,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755ea671a1c34044fa165247aaf6f419ca39caa6003aee791a0df2713d8f1b6d"
+checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1291,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc95a2e67091e44791d4ea300ff744be5293f394f1bafd9f78c080814d35956e"
+checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1301,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a179641d1b93920829a62f15e87c0ed791b6c8db2271ba0fd7c2686090510214"
+checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1313,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dff85ebcaab8c441b0e3f7ae40a6963ecea8a9f5e74f647e33fcf5ec9a1e89e"
+checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1335,9 +1334,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rayon"
@@ -1405,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -1519,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1587,19 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
-
-[[package]]
-name = "twox-hash"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
+checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
 
 [[package]]
 name = "unicode-ident"
@@ -1609,9 +1598,9 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unindent"
@@ -1643,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1745,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -1780,24 +1769,24 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]
@@ -1829,9 +1818,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
@@ -1950,18 +1939,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1970,9 +1959,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8"
+checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
 
 [[package]]
 name = "zstd"

--- a/bin/check.bash
+++ b/bin/check.bash
@@ -69,7 +69,7 @@ stdmsg "Checking shell scripts with shellcheck..."
 find . -type d \( -path ./MHLib_v3.1.0.0_64bit -o -path ./.venv \) -prune -o -type f \( -name "*.sh" -o -name "*.bash" \) -print0 | xargs -0 shellcheck --enable=all --external-sources
 
 stdmsg "Checking shell script formatting with shfmt..."
-shfmt --diff --simplify bin "${python_source_dirs[@]}" src
+shfmt --diff bin "${python_source_dirs[@]}" src
 
 stdmsg "Running ruff..."
 ruff check .

--- a/bin/check.bash
+++ b/bin/check.bash
@@ -49,6 +49,7 @@ cargo fmt --all -- --check
 cargo clippy
 cargo test
 cargo build
+cargo doc --no-deps
 maturin develop
 
 stdmsg "Checking Python type hints with mypy..."

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
 allowed-duplicate-crates = ["getrandom", "twox-hash", "wasi"]
+doc-valid-idents = ["MultiHarp", "PicoQuant", ".."]

--- a/sample_config/multiharp160.json
+++ b/sample_config/multiharp160.json
@@ -2,12 +2,6 @@
     "sync_channel": null,
     "input_channels": [
         {
-            "id": 0,
-            "edge_trigger_level": 250,
-            "edge_trigger": "Falling",
-            "offset": 0
-        },
-        {
             "id": 1,
             "edge_trigger_level": 250,
             "edge_trigger": "Falling",
@@ -21,6 +15,12 @@
         },
         {
             "id": 3,
+            "edge_trigger_level": 250,
+            "edge_trigger": "Falling",
+            "offset": 0
+        },
+        {
+            "id": 4,
             "edge_trigger_level": 250,
             "edge_trigger": "Falling",
             "offset": 0

--- a/src/bin/tdc_toolkit.rs
+++ b/src/bin/tdc_toolkit.rs
@@ -60,6 +60,10 @@ enum Command {
         /// device. Configuration is device-specific; if this field is
         /// omitted and the device supports it, the device will be
         /// opened without changing its current configuration.
+        ///
+        /// The configuration format for MultiHarp is documented in
+        /// [`MH160DeviceConfig`]. JSON examples are available in the
+        /// source distribution's `sample_config` directory.
         #[arg(long, value_hint = ValueHint::FilePath)]
         device_config: Option<PathBuf>,
 

--- a/src/bin/tdc_toolkit.rs
+++ b/src/bin/tdc_toolkit.rs
@@ -1,4 +1,4 @@
-use anyhow::{Error, Result, bail};
+use anyhow::{Context, Error, Result, bail};
 use clap::{Parser, Subcommand, ValueEnum, ValueHint};
 use indicatif::{ProgressBar, ProgressStyle};
 use std::fs;
@@ -11,7 +11,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 use strum_macros::Display;
 
-use tdc_toolkit::multiharp::device::{MH160, MH160Device, MH160DeviceConfig};
+use tdc_toolkit::multiharp::device::{MH160, MH160Device};
 use tdc_toolkit::multiharp::device_stub::MH160Stub;
 use tdc_toolkit::multiharp::recording;
 
@@ -127,8 +127,15 @@ fn main() -> Result<()> {
                 DeviceType::MH160Device => {
                     let unboxed_device = match device_config {
                         Some(device_config) => {
-                            let config: MH160DeviceConfig =
-                                serde_json::from_str(fs::read_to_string(device_config)?.as_str())?;
+                            let config =
+                                serde_json::from_str(fs::read_to_string(&device_config)?.as_str())
+                                    .with_context(|| {
+                                        format!(
+                                            "Error while parsing config file at {}",
+                                            device_config.display()
+                                        )
+                                    })?;
+
                             MH160Device::from_config(mh_device_index, config)?
                         }
                         None => MH160Device::from_current_config(mh_device_index)?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,59 @@
+//! Rust CLI and library, as well as Python bindings, for working with
+//! [time-to-digital converters
+//! (TDCs)](https://en.wikipedia.org/wiki/Time-to-digital_converter)
+//! such as the [PicoQuant MultiHarp
+//! 160](https://www.picoquant.com/products/category/tcspc-and-time-tagging-modules/multiharp-160).
+//!
+//! Please see the project README for information on contributing to the project.
+//!
+//! ## How to use
+//!
+//! This library contains components that can be connected through
+//! [standard MPSC Rust channels](std::sync::mpsc) to form data
+//! processing pipelines. Broadly speaking, these components fall into
+//! the folowing categories:
+//!
+//! ### Device
+//!
+//! A pipeline usually starts with a device. These may be real,
+//! physical devices such as the MultiHarp 160, or they may be
+//! simulated devices. The goal of the device component is to produce
+//! data that closely follows the proprietary format of the device.
+//!
+//! * [multiharp]
+//!
+//! ### Normalizer
+//!
+//! After the device produces a stream of proprietary data, the
+//! normalizer transforms it into a common format that can be used for
+//! further processing.
+//!
+//! * [multiharp]
+//!
+//! ### Output
+//!
+//! Output components accept normalized data and do something with it,
+//! like write it to disk.
+//!
+//! * [output]
+//!
+//! ## Examples
+//!
+//! For now, the best example of a complete pipeline is probably the
+//! `tdc_toolkit` CLI implementation.
+//!
+//! ## API stability
+//!
+//! We follow the [Semantic Versioning 2.0.0](https://semver.org/)
+//! standard.
+//!
+//! As the library only supports one type of device at present, it is
+//! likely that the APIs and data formats used to connect the
+//! components above will change as more devices are added and the
+//! problem space is better understood. For this reason, as of July
+//! 2025, we do not anticipate making a 1.x.x release in the near
+//! future.
+
 pub mod multiharp;
 pub mod output;
 pub mod types;

--- a/src/multiharp.rs
+++ b/src/multiharp.rs
@@ -1,3 +1,5 @@
+//! Devices and normalizers related to the PicoQuant MultiHarp series of time-to-digital converters.
+
 pub mod mhlib_wrapper_header;
 
 #[cfg_attr(

--- a/src/multiharp/device.rs
+++ b/src/multiharp/device.rs
@@ -52,17 +52,17 @@ impl MH160ChannelId {
     }
 }
 
-impl Into<u8> for MH160ChannelId {
-    fn into(self) -> u8 {
-        self.0
-    }
-}
-
 impl TryFrom<u8> for MH160ChannelId {
     type Error = anyhow::Error;
 
     fn try_from(value: u8) -> Result<Self> {
         Self::new(value)
+    }
+}
+
+impl From<MH160ChannelId> for u8 {
+    fn from(value: MH160ChannelId) -> Self {
+        value.0
     }
 }
 

--- a/src/multiharp/mhlib_wrapper.rs
+++ b/src/multiharp/mhlib_wrapper.rs
@@ -20,7 +20,9 @@ use self::bindings::{
 };
 
 use super::mhlib_wrapper_header;
-use super::mhlib_wrapper_header::{Edge, MeasurementControl, Mode, RefSource};
+use super::mhlib_wrapper_header::{
+    Edge, MH160InternalChannelId, MeasurementControl, Mode, RefSource,
+};
 
 fn handle_error(ret: c_int) -> Result<()> {
     let mut error_string: [u8; 40] = [0; 40];
@@ -210,38 +212,61 @@ pub fn set_sync_deadtime(device_index: u8, on: bool, deadtime_ps: i32) -> Result
 
 pub fn set_input_edge_trigger(
     device_index: u8,
-    channel: u8,
+    channel: MH160InternalChannelId,
     level: i32,
     mac_edge: Edge,
 ) -> Result<()> {
+    let channel_u8: u8 = channel.into();
     unsafe {
-        let ret = MH_SetInputEdgeTrg(device_index.into(), channel.into(), level, mac_edge as i32);
+        let ret = MH_SetInputEdgeTrg(
+            device_index.into(),
+            channel_u8.into(),
+            level,
+            mac_edge as i32,
+        );
         handle_error(ret)?;
         Ok(())
     }
 }
 
-pub fn set_input_channel_offset(device_index: u8, channel: u8, offset: i32) -> Result<()> {
+pub fn set_input_channel_offset(
+    device_index: u8,
+    channel: MH160InternalChannelId,
+    offset: i32,
+) -> Result<()> {
+    let channel_u8: u8 = channel.into();
     unsafe {
-        let ret = MH_SetInputChannelOffset(device_index.into(), channel.into(), offset);
+        let ret = MH_SetInputChannelOffset(device_index.into(), channel_u8.into(), offset);
         handle_error(ret)?;
         Ok(())
     }
 }
 
-pub fn set_input_channel_enable(device_index: u8, channel: u8, enable: bool) -> Result<()> {
+pub fn set_input_channel_enable(
+    device_index: u8,
+    channel: MH160InternalChannelId,
+    enable: bool,
+) -> Result<()> {
+    let channel_u8: u8 = channel.into();
     unsafe {
-        let ret = MH_SetInputChannelEnable(device_index.into(), channel.into(), i32::from(enable));
+        let ret =
+            MH_SetInputChannelEnable(device_index.into(), channel_u8.into(), i32::from(enable));
         handle_error(ret)?;
         Ok(())
     }
 }
 
-pub fn set_input_deadtime(device_index: u8, channel: u8, on: bool, deadtime_ps: i32) -> Result<()> {
+pub fn set_input_deadtime(
+    device_index: u8,
+    channel: MH160InternalChannelId,
+    on: bool,
+    deadtime_ps: i32,
+) -> Result<()> {
+    let channel_u8: u8 = channel.into();
     unsafe {
         let ret = MH_SetInputDeadTime(
             device_index.into(),
-            channel.into(),
+            channel_u8.into(),
             i32::from(on),
             deadtime_ps,
         );
@@ -350,13 +375,14 @@ pub fn ctc_status(device_index: u8) -> Result<i32> {
     }
 }
 
-pub fn get_histogram(device_index: u8, channel: u8) -> Result<Vec<u32>> {
+pub fn get_histogram(device_index: u8, channel: MH160InternalChannelId) -> Result<Vec<u32>> {
+    let channel_u8: u8 = channel.into();
     let mut histogram_vec: Vec<u32> = vec![0u32; 65536];
     unsafe {
         let ret = MH_GetHistogram(
             device_index.into(),
             histogram_vec.as_mut_ptr(),
-            channel.into(),
+            channel_u8.into(),
         );
         handle_error(ret)?;
         Ok(histogram_vec)
@@ -390,10 +416,11 @@ pub fn get_sync_rate(device_index: u8) -> Result<i32> {
     }
 }
 
-pub fn get_count_rate(device_index: u8, channel: u8) -> Result<i32> {
+pub fn get_count_rate(device_index: u8, channel: MH160InternalChannelId) -> Result<i32> {
     let mut count_rate: i32 = 0;
+    let channel_u8: u8 = channel.into();
     unsafe {
-        let ret = MH_GetCountRate(device_index.into(), channel.into(), &mut count_rate);
+        let ret = MH_GetCountRate(device_index.into(), channel_u8.into(), &mut count_rate);
         handle_error(ret)?;
         Ok(count_rate)
     }

--- a/src/multiharp/mhlib_wrapper.rs
+++ b/src/multiharp/mhlib_wrapper.rs
@@ -217,14 +217,8 @@ pub fn set_input_edge_trigger(
     level: i32,
     mac_edge: Edge,
 ) -> Result<()> {
-    let channel_u8: u8 = channel.into();
     unsafe {
-        let ret = MH_SetInputEdgeTrg(
-            device_index.into(),
-            channel_u8.into(),
-            level,
-            mac_edge as i32,
-        );
+        let ret = MH_SetInputEdgeTrg(device_index.into(), channel.into(), level, mac_edge as i32);
         handle_error(ret)?;
         Ok(())
     }
@@ -235,9 +229,8 @@ pub fn set_input_channel_offset(
     channel: MH160InternalChannelId,
     offset: i32,
 ) -> Result<()> {
-    let channel_u8: u8 = channel.into();
     unsafe {
-        let ret = MH_SetInputChannelOffset(device_index.into(), channel_u8.into(), offset);
+        let ret = MH_SetInputChannelOffset(device_index.into(), channel.into(), offset);
         handle_error(ret)?;
         Ok(())
     }
@@ -248,10 +241,8 @@ pub fn set_input_channel_enable(
     channel: MH160InternalChannelId,
     enable: bool,
 ) -> Result<()> {
-    let channel_u8: u8 = channel.into();
     unsafe {
-        let ret =
-            MH_SetInputChannelEnable(device_index.into(), channel_u8.into(), i32::from(enable));
+        let ret = MH_SetInputChannelEnable(device_index.into(), channel.into(), i32::from(enable));
         handle_error(ret)?;
         Ok(())
     }
@@ -263,11 +254,10 @@ pub fn set_input_deadtime(
     on: bool,
     deadtime_ps: i32,
 ) -> Result<()> {
-    let channel_u8: u8 = channel.into();
     unsafe {
         let ret = MH_SetInputDeadTime(
             device_index.into(),
-            channel_u8.into(),
+            channel.into(),
             i32::from(on),
             deadtime_ps,
         );
@@ -377,13 +367,12 @@ pub fn ctc_status(device_index: u8) -> Result<i32> {
 }
 
 pub fn get_histogram(device_index: u8, channel: MH160InternalChannelId) -> Result<Vec<u32>> {
-    let channel_u8: u8 = channel.into();
     let mut histogram_vec: Vec<u32> = vec![0u32; 65536];
     unsafe {
         let ret = MH_GetHistogram(
             device_index.into(),
             histogram_vec.as_mut_ptr(),
-            channel_u8.into(),
+            channel.into(),
         );
         handle_error(ret)?;
         Ok(histogram_vec)
@@ -419,9 +408,8 @@ pub fn get_sync_rate(device_index: u8) -> Result<i32> {
 
 pub fn get_count_rate(device_index: u8, channel: MH160InternalChannelId) -> Result<i32> {
     let mut count_rate: i32 = 0;
-    let channel_u8: u8 = channel.into();
     unsafe {
-        let ret = MH_GetCountRate(device_index.into(), channel_u8.into(), &raw mut count_rate);
+        let ret = MH_GetCountRate(device_index.into(), channel.into(), &raw mut count_rate);
         handle_error(ret)?;
         Ok(count_rate)
     }

--- a/src/multiharp/mhlib_wrapper.rs
+++ b/src/multiharp/mhlib_wrapper.rs
@@ -100,7 +100,7 @@ pub fn get_hardware_info(device_index: u8) -> Result<(String, String, String)> {
 pub fn get_feature(device_index: u8) -> Result<i32> {
     let mut features = 0i32;
     unsafe {
-        let ret = MH_GetFeatures(device_index.into(), &mut features);
+        let ret = MH_GetFeatures(device_index.into(), &raw mut features);
         handle_error(ret)?;
         Ok(features)
     }
@@ -119,7 +119,8 @@ pub fn get_base_resolution(device_index: u8) -> Result<(f64, i32)> {
     let mut resolution: f64 = 0.0;
     let mut bin_steps: i32 = 0;
     unsafe {
-        let ret = MH_GetBaseResolution(device_index.into(), &mut resolution, &mut bin_steps);
+        let ret =
+            MH_GetBaseResolution(device_index.into(), &raw mut resolution, &raw mut bin_steps);
         handle_error(ret)?;
         Ok((resolution, bin_steps))
     }
@@ -128,7 +129,7 @@ pub fn get_base_resolution(device_index: u8) -> Result<(f64, i32)> {
 pub fn get_number_of_input_channels(device_index: u8) -> Result<i32> {
     let mut num_channels: i32 = 0;
     unsafe {
-        let ret = MH_GetNumOfInputChannels(device_index.into(), &mut num_channels);
+        let ret = MH_GetNumOfInputChannels(device_index.into(), &raw mut num_channels);
         handle_error(ret)?;
         Ok(num_channels)
     }
@@ -137,7 +138,7 @@ pub fn get_number_of_input_channels(device_index: u8) -> Result<i32> {
 pub fn get_number_of_modules(device_index: u8) -> Result<i32> {
     let mut number_of_modules = 0;
     unsafe {
-        let ret = MH_GetNumOfModules(device_index.into(), &mut number_of_modules);
+        let ret = MH_GetNumOfModules(device_index.into(), &raw mut number_of_modules);
         handle_error(ret)?;
         Ok(number_of_modules)
     }
@@ -150,8 +151,8 @@ pub fn get_module_info(device_index: u8, module_index: u8) -> Result<(i32, i32)>
         let ret = MH_GetModuleInfo(
             device_index.into(),
             module_index.into(),
-            &mut model_code,
-            &mut version_code,
+            &raw mut model_code,
+            &raw mut version_code,
         );
         handle_error(ret)?;
         Ok((model_code, version_code))
@@ -310,7 +311,7 @@ pub fn set_offset(device_index: u8, offset: i32) -> Result<()> {
 pub fn set_histogram_length(device_index: u8, len_code: i32) -> Result<i32> {
     let mut actual_length = 0i32;
     unsafe {
-        let ret = MH_SetHistoLen(device_index.into(), len_code, &mut actual_length);
+        let ret = MH_SetHistoLen(device_index.into(), len_code, &raw mut actual_length);
         handle_error(ret)?;
         Ok(actual_length)
     }
@@ -369,7 +370,7 @@ pub fn stop_measurement(device_index: u8) -> Result<()> {
 pub fn ctc_status(device_index: u8) -> Result<i32> {
     let mut ctc_status_val = 0i32;
     unsafe {
-        let ret = MH_CTCStatus(device_index.into(), &mut ctc_status_val);
+        let ret = MH_CTCStatus(device_index.into(), &raw mut ctc_status_val);
         handle_error(ret)?;
         Ok(ctc_status_val)
     }
@@ -401,7 +402,7 @@ pub fn get_all_histogram(device_index: u8) -> Result<Vec<u32>> {
 pub fn get_resolution(device_index: u8) -> Result<f64> {
     let mut resolution: f64 = 0.0;
     unsafe {
-        let ret = MH_GetResolution(device_index.into(), &mut resolution);
+        let ret = MH_GetResolution(device_index.into(), &raw mut resolution);
         handle_error(ret)?;
         Ok(resolution)
     }
@@ -410,7 +411,7 @@ pub fn get_resolution(device_index: u8) -> Result<f64> {
 pub fn get_sync_rate(device_index: u8) -> Result<i32> {
     let mut sync_rate: i32 = 0;
     unsafe {
-        let ret = MH_GetSyncRate(device_index.into(), &mut sync_rate);
+        let ret = MH_GetSyncRate(device_index.into(), &raw mut sync_rate);
         handle_error(ret)?;
         Ok(sync_rate)
     }
@@ -420,7 +421,7 @@ pub fn get_count_rate(device_index: u8, channel: MH160InternalChannelId) -> Resu
     let mut count_rate: i32 = 0;
     let channel_u8: u8 = channel.into();
     unsafe {
-        let ret = MH_GetCountRate(device_index.into(), channel_u8.into(), &mut count_rate);
+        let ret = MH_GetCountRate(device_index.into(), channel_u8.into(), &raw mut count_rate);
         handle_error(ret)?;
         Ok(count_rate)
     }
@@ -432,7 +433,7 @@ pub fn get_all_count_rates(device_index: u8) -> Result<(i32, Vec<i32>)> {
     unsafe {
         let ret = MH_GetAllCountRates(
             device_index.into(),
-            &mut sync_rate,
+            &raw mut sync_rate,
             count_rates.as_mut_ptr(),
         );
         handle_error(ret)?;
@@ -443,7 +444,7 @@ pub fn get_all_count_rates(device_index: u8) -> Result<(i32, Vec<i32>)> {
 pub fn get_flags(device_index: u8) -> Result<i32> {
     let mut flags = 0i32;
     unsafe {
-        let ret = MH_GetFlags(device_index.into(), &mut flags);
+        let ret = MH_GetFlags(device_index.into(), &raw mut flags);
         handle_error(ret)?;
         Ok(flags)
     }
@@ -452,7 +453,7 @@ pub fn get_flags(device_index: u8) -> Result<i32> {
 pub fn get_elapsed_measurement_time(device_index: u8) -> Result<f64> {
     let mut elapsed_time = 0f64;
     unsafe {
-        let ret = MH_GetElapsedMeasTime(device_index.into(), &mut elapsed_time);
+        let ret = MH_GetElapsedMeasTime(device_index.into(), &raw mut elapsed_time);
         handle_error(ret)?;
         Ok(elapsed_time)
     }
@@ -463,7 +464,12 @@ pub fn get_start_time(device_index: u8) -> Result<(u32, u32, u32)> {
     let mut time1 = 0u32;
     let mut time0 = 0u32;
     unsafe {
-        let ret = MH_GetStartTime(device_index.into(), &mut time2, &mut time1, &mut time0);
+        let ret = MH_GetStartTime(
+            device_index.into(),
+            &raw mut time2,
+            &raw mut time1,
+            &raw mut time0,
+        );
         handle_error(ret)?;
         Ok((time2, time1, time0))
     }
@@ -473,7 +479,7 @@ pub fn get_warnings(device_index: u8) -> Result<String> {
     let mut warnings: i32 = 0;
     let mut text = [0u8; 16384];
     unsafe {
-        let ret = MH_GetWarnings(device_index.into(), &mut warnings);
+        let ret = MH_GetWarnings(device_index.into(), &raw mut warnings);
         handle_error(ret)?;
         let ret = MH_GetWarningsText(
             device_index.into(),
@@ -495,7 +501,7 @@ pub fn read_fifo(device_index: u8) -> Result<Vec<u32>> {
         let ret = MH_ReadFiFo(
             device_index.into(),
             record_buffer.as_mut_ptr(),
-            &mut num_records,
+            &raw mut num_records,
         );
         handle_error(ret)?;
         record_buffer.set_len(num_records.try_into()?);
@@ -506,7 +512,7 @@ pub fn read_fifo(device_index: u8) -> Result<Vec<u32>> {
 pub fn is_measurement_running(device_index: u8) -> Result<bool> {
     let mut ctc_status: i32 = 0;
     unsafe {
-        let ret = MH_CTCStatus(device_index.into(), &mut ctc_status);
+        let ret = MH_CTCStatus(device_index.into(), &raw mut ctc_status);
         handle_error(ret)?;
         Ok(ctc_status == 0)
     }

--- a/src/multiharp/mhlib_wrapper_header.rs
+++ b/src/multiharp/mhlib_wrapper_header.rs
@@ -1,16 +1,19 @@
+//! Values and data structures needed by [`mhlib_wrapper`](super::mhlib_wrapper) as well as
+//! [`mhlib_wrapper_stub`](super::mhlib_wrapper_stub).
+//!
+//! Many of these values are derived from `mhdefin.h`, which is
+//! bundled with the MultiHarp driver release. The values are copied
+//! here to avoid a hard dependency on downloading the proprietary
+//! MultiHarp shared library when using this library on non-x64
+//! platforms or with non-MultiHarp systems.
+//!
+//! The original constant names are preserved as comments.
+
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::convert::Into;
 
 use super::device::MH160ChannelId;
-
-// These values are derived from mhdefin.h, which is bundled with the
-// MultiHarp driver release. The values are copied here to avoid a
-// hard dependency on the using mhlib module or downloading the
-// proprietary MultiHarp shared library when using this library on
-// non-x64 platforms or with non-MultiHarp systems.
-//
-// The original constant names are preserved as comments.
 
 pub const TTREADMAX: usize = 1_048_576;
 
@@ -61,6 +64,16 @@ pub enum MeasurementControl {
     SwitchStartSwitchStop = 6_i32, // MEASCTRL_SW_START_SW_STOP
 }
 
+/// The channel ID corresponding to the internal representation used
+/// in the official mhlib library. The ID must be greater than or
+/// equal to `0`. The sync channel cannot be represented in this
+/// scheme.
+///
+/// For example, the channel labeled `1` on the device's front panel
+/// is referred to as channel `0` here.
+///
+/// This struct is used for low-level APIs that interface directly
+/// with mhlib. Higher-level APIs use [`MH160ChannelId`].
 #[derive(PartialEq, Clone, Debug)]
 pub struct MH160InternalChannelId(u8);
 

--- a/src/multiharp/mhlib_wrapper_header.rs
+++ b/src/multiharp/mhlib_wrapper_header.rs
@@ -1,5 +1,8 @@
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::convert::Into;
+
+use super::device::MH160ChannelId;
 
 // These values are derived from mhdefin.h, which is bundled with the
 // MultiHarp driver release. The values are copied here to avoid a
@@ -56,4 +59,26 @@ pub enum MeasurementControl {
     WhiteRabbitM2S = 4_i32,        // MEASCTRL_WR_M2S
     WhiteRabbitS2M = 5_i32,        // MEASCTRL_WR_S2M
     SwitchStartSwitchStop = 6_i32, // MEASCTRL_SW_START_SW_STOP
+}
+
+#[derive(PartialEq, Clone, Debug)]
+pub struct MH160InternalChannelId(u8);
+
+impl MH160InternalChannelId {
+    #[must_use]
+    pub fn new(value: u8) -> Self {
+        Self(value)
+    }
+}
+
+impl From<MH160ChannelId> for MH160InternalChannelId {
+    fn from(value: MH160ChannelId) -> Self {
+        Self::new(Into::<u8>::into(value) - 1)
+    }
+}
+
+impl Into<u8> for MH160InternalChannelId {
+    fn into(self) -> u8 {
+        self.0
+    }
 }

--- a/src/multiharp/mhlib_wrapper_header.rs
+++ b/src/multiharp/mhlib_wrapper_header.rs
@@ -77,8 +77,8 @@ impl From<MH160ChannelId> for MH160InternalChannelId {
     }
 }
 
-impl Into<u8> for MH160InternalChannelId {
-    fn into(self) -> u8 {
-        self.0
+impl From<MH160InternalChannelId> for u8 {
+    fn from(value: MH160InternalChannelId) -> Self {
+        value.0
     }
 }

--- a/src/multiharp/mhlib_wrapper_header.rs
+++ b/src/multiharp/mhlib_wrapper_header.rs
@@ -82,3 +82,9 @@ impl From<MH160InternalChannelId> for u8 {
         value.0
     }
 }
+
+impl From<MH160InternalChannelId> for i32 {
+    fn from(value: MH160InternalChannelId) -> Self {
+        value.0.into()
+    }
+}

--- a/src/multiharp/mhlib_wrapper_stub.rs
+++ b/src/multiharp/mhlib_wrapper_stub.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 
-use super::mhlib_wrapper_header::{Edge, MeasurementControl, Mode, RefSource};
+use super::mhlib_wrapper_header::{
+    Edge, MH160InternalChannelId, MeasurementControl, Mode, RefSource,
+};
 
 pub fn get_library_version() -> Result<String> {
     Ok("Stub".to_string())
@@ -80,24 +82,32 @@ pub fn set_sync_deadtime(_device_index: u8, _on: bool, _deadtime_ps: i32) -> Res
 
 pub fn set_input_edge_trigger(
     _device_index: u8,
-    _channel: u8,
+    _channel: MH160InternalChannelId,
     _level: i32,
     _mac_edge: Edge,
 ) -> Result<()> {
     Ok(())
 }
 
-pub fn set_input_channel_offset(_device_index: u8, _channel: u8, _offset: i32) -> Result<()> {
+pub fn set_input_channel_offset(
+    _device_index: u8,
+    _channel: MH160InternalChannelId,
+    _offset: i32,
+) -> Result<()> {
     Ok(())
 }
 
-pub fn set_input_channel_enable(_device_index: u8, _channel: u8, _enable: bool) -> Result<()> {
+pub fn set_input_channel_enable(
+    _device_index: u8,
+    _channel: MH160InternalChannelId,
+    _enable: bool,
+) -> Result<()> {
     Ok(())
 }
 
 pub fn set_input_deadtime(
     _device_index: u8,
-    _channel: u8,
+    _channel: MH160InternalChannelId,
     _on: bool,
     _deadtime_ps: i32,
 ) -> Result<()> {
@@ -153,7 +163,7 @@ pub fn ctc_status(_device_index: u8) -> Result<i32> {
     Ok(0i32)
 }
 
-pub fn get_histogram(_device_index: u8, _channel: u8) -> Result<Vec<u32>> {
+pub fn get_histogram(_device_index: u8, _channel: MH160InternalChannelId) -> Result<Vec<u32>> {
     let histogram_vec: Vec<u32> = vec![0u32; 65536];
     Ok(histogram_vec)
 }
@@ -170,7 +180,8 @@ pub fn get_resolution(_device_index: u8) -> Result<f64> {
 pub fn get_sync_rate(_device_index: u8) -> Result<i32> {
     Ok(0i32)
 }
-pub fn get_count_rate(_device_index: u8, _channel: u8) -> Result<i32> {
+
+pub fn get_count_rate(_device_index: u8, _channel: MH160InternalChannelId) -> Result<i32> {
     Ok(0i32)
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,1 +1,3 @@
+//! Outputs that accept normalized data and do something with it.
+
 pub mod parquet;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+//! Common, normalized types used to communicate across channels.
+
 pub struct NormalizedTimeTag {
     pub channel_id: u16,
 


### PR DESCRIPTION
Closes https://github.com/moonshot-nagayama-pj/tdc-toolkit/issues/21

This should help make using the MultiHarp easier, but it does mean updating existing configurations (by adding 1 to all of the channel IDs) and is therefore a **breaking change**.

* APIs and configuration format changed to require channel IDs to start from 1 rather than 0
* More user-friendly error messages provided when configuration parsing fails
* Dependency updates and fixes to new issues found by updating Clippy
* Basic documentation added to clarify what channel IDs mean, which can be viewed locally by running `cargo doc --no-deps --open`